### PR TITLE
chore: add node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bem-naming": "^1.0.1",
     "nyc": "^6.1.1"
   },
+  "engines": { "node" : ">=4.0.0" },
   "devDependencies": {
     "ava": "^0.13.0"
   }


### PR DESCRIPTION
Since package uses es6 features that doesn't supported in node 0.12 and below.
